### PR TITLE
Fix not working if there's a space in the username

### DIFF
--- a/SetupContextMenu.ps1
+++ b/SetupContextMenu.ps1
@@ -137,7 +137,7 @@ $profiles | ForEach-Object {
         }
         $labelAdmin_f = "$label_f (Admin)"
         
-        $command_f = "$env:LOCALAPPDATA\Microsoft\WindowsApps\wt.exe -p `"$profileName`" -d `"%V\.`""
+        $command_f = "`"$env:LOCALAPPDATA\Microsoft\WindowsApps\wt.exe`" -p `"$profileName`" -d `"%V\.`""
         $commandAdmin_f = "powershell -WindowStyle hidden -Command `"Start-Process powershell -WindowStyle hidden -Verb RunAs -ArgumentList `"`"`"`"-Command $env:LOCALAPPDATA\Microsoft\WindowsApps\wt.exe -p '$profileName' -d '%V\.'`"`"`"`""
         
         if($configEntry.icon){


### PR DESCRIPTION
If there is a space in the username then the path to the wsl gets broken in the context menu command. Fixed by putting the path as a string.