### PR TITLE
Add option to overwrite hidden flag from settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Put any icon file into `icon` folder and modify the `config.json` like the follo
         },
         "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}": {
             "showRunAs": true
+        },
+        "{b453ae62-4e3d-5e58-b989-0a998ec441b8}": {
+            "hidden": true
         }
     }
 }
@@ -56,6 +59,7 @@ Put any icon file into `icon` folder and modify the `config.json` like the follo
   - extended[bool]: if set this to true, context menu will only show up when right click with `shift`
 - profiles
   - guid[string]: this GUID of your profile defined in `settings.json`
+    - hidden[bool]: overwrites the visibility of the profile, if defined
     - icon[string]: filename of your ico file, **you must put this file in icon folder**
     - label[string]: context menu label
     - showRunAs[bool]: add `run as administrator` item for this profile

--- a/SetupContextMenu.ps1
+++ b/SetupContextMenu.ps1
@@ -114,7 +114,11 @@ $profiles | ForEach-Object {
     $subItemRegPath = "$subMenuRegPath$profileSortOrderString$leagaleName"
     $subItemAdminRegPath = "$subItemRegPath-Admin"
 
-    $isHidden = $_.hidden
+    if ($configEntry.hidden -eq $null) {
+        $isHidden = $_.hidden
+    } else {
+        $isHidden = $configEntry.hidden
+    }
     $commandLine = $_.commandline
     $source = $_.source
     $icoPath = ""


### PR DESCRIPTION
Adds an option to overwrite the visibility of a profile from settings.json. This could be used to disable the creation of context menu entries of profiles, that should be shown in windows terminal but not the context menu. 