### PR TITLE
Fix/pre existing issues

### DIFF
--- a/SetupContextMenu.ps1
+++ b/SetupContextMenu.ps1
@@ -3,7 +3,8 @@ Param(
 )
 
 # Global definitions
-$wtProfilesPath = "$env:LocalAppData\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json"
+$wtPackagePath = Get-ChildItem "$env:LocalAppData\Packages\Microsoft.WindowsTerminal*" | Select-Object -ExpandProperty FullName -First 1
+$wtProfilesPath = "$wtPackagePath\LocalState\settings.json"
 $customConfigPath = "$PSScriptRoot\config.json"
 $resourcePath = "$env:LOCALAPPDATA\WindowsTerminalContextIcons\"
 $contextMenuIcoName = "terminal.ico"

--- a/SetupContextMenu.ps1
+++ b/SetupContextMenu.ps1
@@ -62,6 +62,7 @@ if($uninstall) {
 Write-Output "Copy icons => $resourcePath"
 
 # Load the custom config
+$config = $null
 if((Test-Path -Path $customConfigPath)) {
     $rawConfig = (Get-Content $customConfigPath -Encoding UTF8) -replace '^\s*\/\/.*' | Out-String
     $config = (ConvertFrom-Json -InputObject $rawConfig)


### PR DESCRIPTION
Two issues detected by AI:

1. Initialize $config to $null before loading config.json

When config.json doesn't exist, `$config` remains undefined. PowerShell
tolerates property access on undefined variables by returning `$null`,
but this is fragile. Explicitly initialize to `$null`.


2. Detect Windows Terminal package path dynamically

The stable, Preview, and Dev variants of Windows Terminal use
different package names (Microsoft.WindowsTerminal_8wekyb3d8bbwe,
Microsoft.WindowsTerminalPreview_..., etc.). Dynamically search for
any Microsoft.WindowsTerminal* package instead of hardcoding.
